### PR TITLE
Fix assertion for payment value in notebook

### DIFF
--- a/u1/03-kontrollfluss.ipynb
+++ b/u1/03-kontrollfluss.ipynb
@@ -119,7 +119,7 @@
    "outputs": [],
    "source": [
     "assert 'input' in c, \"Aufg. 1: Verwenden Sie die input Funktion\"\n",
-    "assert 'Zahlung:  475.0' in cap.stdout, \"Aufg. 1: Die Berechnung stimmt nicht\"\n",
+    "assert 'Zahlung: 475.0' in cap.stdout, \"Aufg. 1: Die Berechnung stimmt nicht\"\n",
     "assert cap.stdout.count('Zahlung') == 1, \"Aufg. 1: Die Ausgabe stimmt nicht\"\n",
     "del cap"
    ]


### PR DESCRIPTION
Removed doubled space in line 122 between 'Zahlung:' and '475.0', in order to not provoke an assertion error when output is actually correct with one space in between.