### PR TITLE
Fix assertion messages in lohnberechnung tests

### DIFF
--- a/u2/04-funktionen.ipynb
+++ b/u2/04-funktionen.ipynb
@@ -218,8 +218,8 @@
     "from nose.tools import assert_almost_equal\n",
     "assert_almost_equal(lohnberechnung(10, 45), 475.0, \"Falsches Ergebnis\")\n",
     "assert_almost_equal(lohnberechnung(10, 15), 150.0, \"Falsches Ergebnis\")\n",
-    "assert_equal(lohnberechnung(\"zehn\", 10), \"Fehler, bitte gib eine Zahl ein.\")\n",
-    "assert_equal(lohnberechnung(10, \"zehn\"), \"Fehler, bitte gib eine Zahl ein.\")"
+    "assert_equal(lohnberechnung(\"zehn\", 10), \"Fehler, bitte gib eine Zahl ein\")\n",
+    "assert_equal(lohnberechnung(10, \"zehn\"), \"Fehler, bitte gib eine Zahl ein\")"
    ]
   },
   {


### PR DESCRIPTION
Removed dot '.' in two assert statements in order to match the necessary output error message 'Fehler, bitte gib eine Zahl ein' from the task and avoid confusion about a thrown assertion error due to the dot.